### PR TITLE
Support for host aliases.

### DIFF
--- a/bin/gtransfer.sh
+++ b/bin/gtransfer.sh
@@ -6,7 +6,7 @@
 
 :<<COPYRIGHT
 
-Copyright (C) 2010, 2011 Frank Scheiner, HLRS, Universitaet Stuttgart
+Copyright (C) 2010, 2011, 2013 Frank Scheiner, HLRS, Universitaet Stuttgart
 Copyright (C) 2011, 2012, 2013 Frank Scheiner
 
 The program is distributed under the terms of the GNU General Public License
@@ -33,7 +33,7 @@ COPYRIGHT
 #  prevent "*" expansion (filename globbing)
 set -f
 
-version="0.1.2"
+version="0.2.0"
 gsiftpUserParams=""
 
 #  path to configuration files (prefer system paths!)
@@ -615,6 +615,40 @@ if [[ "$gsiftpSourceUrl" == "" || \
 else
 	#  create directory for temp files
 	mkdir -p "$__GLOBAL__gtTmpDir"
+
+	# dealias URLs	
+	if hash halias &>/dev/null; then
+		# remove everything after and including the first "/". As an alias
+		# mustn't contain any forward slashes, if an alias is used in the URLs,
+		# it's everything from start to the first forward slash.
+		_tmpSourceAlias=${gsiftpSourceUrl%%\/*}
+		_tmpDestinationAlias=${gsiftpDestinationUrl%%\/*}
+	
+		_tmpSourceAliasValue=$( halias --dealias "$_tmpSourceAlias" )
+		if [[ $? != 0 ]]; then
+			echo "E: Dealiasing failed!"
+			exit $_gtransfer_exit_software
+		fi
+		_tmpDestinationAliasValue=$( halias --dealias "$_tmpDestinationAlias" )
+		if [[ $? != 0 ]]; then
+			echo "E: Dealiasing failed!"
+			exit $_gtransfer_exit_software
+		fi
+	
+		# check if the alias value is different from the alias itself
+		if [[ "$_tmpSourceAlias" != "$_tmpSourceAliasValue" ]]; then
+	
+			_tmpSourcePath=${gsiftpSourceUrl#*\/}
+			gsiftpSourceUrl="${_tmpSourceAliasValue}/${_tmpSourcePath}"
+		
+		fi
+	
+		if [[ "$_tmpDestinationAlias" != "$_tmpDestinationAliasValue" ]]; then
+				
+			_tmpDestinationPath=${gsiftpDestinationUrl#*\/}
+			gsiftpDestinationUrl="${_tmpDestinationAliasValue}/${_tmpDestinationPath}"
+		fi
+	fi
 
 	if [[ $autoOptimize -eq 1 ]]; then
 		gsiftpTransferList=$( listTransfer/createTransferList "$gsiftpSourceUrl" "$gsiftpDestinationUrl" )

--- a/bin/halias
+++ b/bin/halias
@@ -1,0 +1,1 @@
+halias.bash

--- a/bin/halias.bash
+++ b/bin/halias.bash
@@ -1,0 +1,305 @@
+# halias - (gtransfer) host aliases cli interface
+
+:<<COPYRIGHT
+
+Copyright (C) 2013 Frank Scheiner, HLRS, Universitaet Stuttgart
+
+The program is distributed under the terms of the GNU General Public License
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+COPYRIGHT
+
+################################################################################
+#  VARIABLES
+################################################################################
+readonly _true=1
+readonly _false=0
+
+readonly __GLOBAL__programName=$( basename "$0" )
+
+readonly __GLOBAL__version="0.1.0"
+
+version="$__GLOBAL__version"
+
+#  path to configuration files (prefer system paths!)
+#  For native OS packages:
+if [[ -e "/etc/gtransfer" ]]; then
+        configurationFilesPath="/etc/gtransfer"
+        #  gtransfer is installed in "/usr/bin", hence the base path is "/usr"
+        basePath="/usr"
+        libPath="$basePath/lib/gtransfer"
+
+#  For installation with "install.sh".
+#sed#elif [[ -e "<GTRANSFER_BASE_PATH>/etc" ]]; then
+#sed#	configurationFilesPath="<GTRANSFER_BASE_PATH>/etc"
+#sed#	basePath=<GTRANSFER_BASE_PATH>
+#sed#	libPath="$gtransferBasePath/lib"
+
+#  According to FHS 2.3, configuration files for packages located in "/opt" have
+#+ to be placed here (if you use a provider super dir below "/opt" for the
+#+ gtransfer files, please also use the same provider super dir below
+#+ "/etc/opt").
+elif [[ -e "/etc/opt/gtransfer" ]]; then
+        configurationFilesPath="/etc/opt/gtransfer"
+        basePath="/opt/gtransfer"
+        libPath="$basePath/lib"
+#elif [[ -e "/etc/opt/<PROVIDER>/gtransfer" ]]; then
+#	configurationFilesPath="/etc/opt/<PROVIDER>/gtransfer"
+#	basePath="/opt/<PROVIDER>/gtransfer"
+#	libPath="$gtransferBasePath/lib"
+
+#  For user install in $HOME:
+elif [[ -e "$HOME/.gtransfer" ]]; then
+        configurationFilesPath="$HOME/.gtransfer"
+        basePath="$HOME/opt/gtransfer"
+        libPath="$basePath/lib"
+
+#  For git deploy, use $BASH_SOURCE
+elif [[ -e "$( dirname $BASH_SOURCE )/../etc" ]]; then
+	configurationFilesPath="$( dirname $BASH_SOURCE )/../etc"
+	basePath="$( dirname $BASH_SOURCE )/../"
+	libPath="$basePath/lib"
+fi
+
+configurationFile="$configurationFilesPath/aliases.conf"
+
+#  Set $_LIB so halias and its libraries can find their includes
+readonly _LIB="$libPath"
+
+################################################################################
+#  INCLUDE LIBRARY FUNCTIONS
+################################################################################
+
+. "$_LIB"/exitCodes.bashlib
+. "$_LIB"/alias.bashlib
+
+################################################################################
+
+
+################################################################################
+#  FUNCTIONS
+################################################################################
+usageMsg()
+{
+        cat <<USAGE
+
+usage:	$__GLOBAL__programName [--help]
+	$__GLOBAL__programName --list
+	$__GLOBAL__programName --dealias alias
+	$__GLOBAL__programName --is-alias alias
+
+--help gives more information
+
+USAGE
+        return
+}
+
+
+helpMsg()
+{
+        cat <<HELP
+
+$(versionMsg)
+
+SYNOPSIS:
+
+$__GLOBAL__programName [OPTION] STRING
+
+DESCRIPTION:
+
+halias (host alias) is a small helper utility providing an interface to the
+alias bashlib. It can be used to list or expand host aliases and also to check
+if a given string is an alias.
+
+OPTIONS:
+
+The options are as follows:
+
+-l, --list		List all available host aliases.
+			
+-d, --dealias STRING	Expand a given string. If STRING is not a host alias,
+			then STRING is just printed.
+			
+-i, --is-alias STRING	Check if a given string is a host alias. Returns 0 if
+			yes, 1 otherwise.
+
+    --help		Display this help and exit.
+
+-V, --version		Output version information and exit.
+
+HELP
+
+	return
+}
+
+
+versionMsg()
+{
+	cat <<-VERSION
+$__GLOBAL__programName v${__GLOBAL__version}
+	VERSION
+	
+	return
+}
+
+
+halias/list()
+{
+	local _userAliases=""
+	local _systemAliases=""
+
+	if [[ -e "$__GLOBAL__userAliasesSource" ]]; then
+		_userAliases=$( alias/list "$__GLOBAL__userAliasesSource" )
+	fi
+	if [[ -e "$__GLOBAL__systemAliasesSource" ]]; then
+		_systemAliases=$( alias/list "$__GLOBAL__systemAliasesSource" )
+	fi
+
+	if [[ ! -z "$_userAliases" && ! -z "$_systemAliases" ]]; then
+	
+		echo -e "$_userAliases\n$_systemAliases" | sort -u
+		
+	elif [[ ! -z "$_userAliases" ]]; then
+	
+		echo "$_userAliases"
+		
+	elif  [[ ! -z "$_systemAliases" ]]; then
+	
+		echo "$_systemAliases"
+	fi
+	
+	return		
+}
+
+
+halias/isAlias()
+{
+	local _string="$1"
+	
+	# The library function checks for existence of aliases source, so not
+	# needed here.
+	#if [[ -e "$__GLOBAL__userAliasesSource" ]]; then
+		if alias/isAlias "$_string" "$__GLOBAL__userAliasesSource"; then
+			return 0
+		fi
+	#fi
+	
+	#if [[ -e "$__GLOBAL__systemAliasesSource" ]]; then
+		if alias/isAlias "$_string" "$__GLOBAL__systemAliasesSource"; then
+			return 0
+		fi
+	#fi
+	
+	return 1
+}
+
+
+halias/dealias()
+{
+	local _string="$1"
+	
+	local _dealiasedString=""
+	
+	_dealiasedString=$( alias/dealias "$_string" "$__GLOBAL__userAliasesSource" )
+	
+	# If _string is a user alias, _dealiasedString will differ from it and
+	# we can return, as user aliases take precedence.
+	if [[ "$_dealiasedString" != "$_string" ]]; then
+		echo "$_dealiasedString"
+		return 0
+	fi
+	
+	_dealiasedString=$( alias/dealias "$_string" "$__GLOBAL__systemAliasesSource" )
+	
+	# If _string is a system alias, _dealiasedString will differ from it...
+	if [[ "$_dealiasedString" != "$_string" ]]; then
+		echo "$_dealiasedString"
+		return 0
+	fi
+	
+	# ...if not, we just return the input string
+	echo "$_string"
+	
+	return
+}
+
+################################################################################
+
+################################################################################
+#  MAIN
+################################################################################
+
+#  load configuration file
+if [[ -e "$configurationFile" ]]; then
+	. "$configurationFile"
+	# The following global vars are defined there:
+	# __GLOBAL__userAliasesSource
+	# __GLOBAL__systemAliasesSource
+else
+	echo "$__GLOBAL__programName: configuration file missing!"
+	exit $_gtransfer_exit_software
+fi
+
+#  correct number of params?
+if [[ "$#" -lt "1" ]]; then
+   # no, so output a usage message
+   usageMsg
+   exit $_gtransfer_exit_usage
+fi
+
+# read in all parameters
+while [[ "$1" != "" ]]; do
+
+	#  only valid params used?
+	if [[   "$1" != "--help" && \
+		"$1" != "--version" && "$1" != "-V" && \
+		"$1" != "--list" && "$1" != "-l" && \
+		"$1" != "--dealias" && "$1" != "-d" && \
+		"$1" != "--is-alias" && "$1" != "-i" \
+	]]; then
+		#  no, so output a usage message
+		usageMsg
+		exit $_gtransfer_exit_usage
+	fi
+
+	#  "--help"
+	if [[ "$1" == "--help" ]]; then
+		helpMsg
+		exit $_gtransfer_exit_ok
+
+	#  "--version|-V"
+	elif [[ "$1" == "--version" || "$1" == "-V" ]]; then
+		versionMsg
+		exit $_gtransfer_exit_ok
+
+	#  "--list|-l"
+	elif [[ "$1" == "--list" || "$1" == "-l" ]]; then
+		halias/list
+		exit
+	
+	# "--is-alias|-i"
+	elif [[ "$1" == "--is-alias" || "$1" == "-i" ]]; then
+		shift 1
+		halias/isAlias "$1"
+		exit
+	
+	# "--dealias|-d"
+	elif [[ "$1" == "--dealias" || "$1" == "-d" ]]; then
+		shift 1
+		halias/dealias "$1"
+		exit
+	fi
+done
+

--- a/etc/gtransfer/aliases.conf_example
+++ b/etc/gtransfer/aliases.conf_example
@@ -1,0 +1,18 @@
+# Aliases configuration file
+
+# Aliases sources can be files or directories. User aliases have precedence over
+# system aliases.
+
+# System aliases
+if [[ -e "$configurationFilesPath" ]]; then
+
+	__GLOBAL__systemAliasesSource="${configurationFilesPath}/aliases"
+# If the system aliases are located elsewhere locally, please configure the next
+# two lines	
+#else
+#	__GLOBAL__systemAliasesSource=<PATH_TO_ALIASES>
+fi
+
+# User aliases
+__GLOBAL__userAliasesSource="$HOME/.gtransfer/aliases"
+

--- a/etc/gtransfer/aliases_example
+++ b/etc/gtransfer/aliases_example
@@ -1,0 +1,6 @@
+alias;gsiftp://host.domain.tld:2812/path/to/file
+alias2;alias
+alias3;$( date )
+alias4;$( echo %alias )
+alias5;alias2
+

--- a/install.sh
+++ b/install.sh
@@ -46,14 +46,17 @@ if [[ "$(basename $0)" == "install.sh" ]]; then
            ./etc/gtransfer/dpath.conf_example \
            ./etc/gtransfer/dparam.conf_example \
            ./etc/gtransfer/dpath.template_example \
-           ./etc/gtransfer/chunkConfig_example "$etcDir"
+           ./etc/gtransfer/chunkConfig_example \
+           ./etc/gtransfer/aliases_example \
+           ./etc/gtransfer/aliases.conf_example "$etcDir"
            
 	cp -r ./etc/bash_completion.d "$etcDir"
 
 	#  copy scripts and...
 	cp ./bin/gtransfer.sh \
 	   ./bin/datapath.sh \
-	   ./bin/defaultparam.sh "$binDir"
+	   ./bin/defaultparam.sh \
+	   ./bin/halias.bash "$binDir"
 	
 	#  ...reconfigure paths inside of the scripts and...
 	#        + reconfigure path to configuration files
@@ -62,6 +65,7 @@ if [[ "$(basename $0)" == "install.sh" ]]; then
 	sed -e "s|<GTRANSFER_BASE_PATH>|$prefixDir/gtransfer|g" -e 's/#sed#//g' -i "$binDir/gtransfer.sh"
 	sed -e "s|<GTRANSFER_BASE_PATH>|$prefixDir/gtransfer|g" -e 's/#sed#//g' -i "$binDir/datapath.sh"
 	sed -e "s|<GTRANSFER_BASE_PATH>|$prefixDir/gtransfer|g" -e 's/#sed#//g' -i "$binDir/defaultparam.sh"
+	sed -e "s|<GTRANSFER_BASE_PATH>|$prefixDir/gtransfer|g" -e 's/#sed#//g' -i "$binDir/halias.bash"
 
 	#  ...make links and...
 	if [[ $userInstall -eq 1 ]]; then
@@ -71,6 +75,7 @@ if [[ "$(basename $0)" == "install.sh" ]]; then
 		ln -s "$binDir/gtransfer.sh" "$linkPath/gt"
 		ln -s "$binDir/datapath.sh" "$linkPath/dpath"
 		ln -s "$binDir/defaultparam.sh" "$linkPath/dparam"
+		ln -s "$binDir/halias.bash" "$linkPath/halias"
 	else
 		linkPath="$binDir"
 		
@@ -79,6 +84,7 @@ if [[ "$(basename $0)" == "install.sh" ]]; then
 		ln -s "gtransfer.sh" "$linkPath/gt"
 		ln -s "datapath.sh" "$linkPath/dpath"
 		ln -s "defaultparam.sh" "$linkPath/dparam"
+		ln -s "halias.bash" "$linkPath/halias"
 	fi
 
 	#  ...copy README and manpages.
@@ -109,6 +115,7 @@ elif [[ "$(basename $0)" == "uninstall.sh" ]]; then
 		rm "$HOME/bin/gt"
 		rm "$HOME/bin/dpath"
 		rm "$HOME/bin/dparam"
+		rm "$HOME/bin/halias"
 
 		#  remove gtransfer dir
 		rm -r "$prefixDir/gtransfer"

--- a/lib/alias.bashlib
+++ b/lib/alias.bashlib
@@ -1,0 +1,300 @@
+#  alias.bashlib - library functions to support aliases
+
+:<<COPYRIGHT
+
+Copyright (C) 2013 Frank Scheiner, HLRS, Universitaet Stuttgart
+
+The program is distributed under the terms of the GNU General Public License
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+COPYRIGHT
+
+
+################################################################################
+# DOCUMENTATION
+################################################################################
+
+# Alias definition:
+#
+# * An alias is resolved to a "host part of a URL"*
+#
+# * An alias mustn't have any forward slashes.
+#
+# * An alias has to be a valid file name.
+#
+# * An alias can refer to another alias. (see "alias3")
+#
+# * No looping allowed (neither by referring to itself directly or indirectly)
+#
+# * The keyword "%alias" is expanded to the current alias. (see "alias4")
+# ____________________
+# *) host part of a URL:
+#
+# gsiftp://host.domain.tld:2811/path/to/file
+# |                           |
+# +-----------\ /-------------+
+#              V
+#          host part
+
+# example aliases file  (ignore "\" before "$")
+:<<ALIASES_FILE
+alias1;gsiftp://gridftp1.deimos.mars:2811
+myGridFTP;alias1
+alias3;\$( doSomething )
+alias4;\$( doSomethingWith %alias )
+ALIASES_FILE
+
+# example aliases dir
+:<<ALIASES_DIR
+alias1
+myGridFTP
+alias3
+alias4
+ALIASES_DIR
+
+# file contents (ignore "\" before "$")
+:<<alias1
+gsiftp://gridftp1.deimos.mars:2811
+alias1
+
+:<<myGridFTP
+alias1
+myGridFTP
+
+:<<alias3
+\$( doSomething )
+alias3
+
+:<<alias4
+\$( doSomethingWith %alias )
+alias4
+
+################################################################################
+# INCLUDES
+################################################################################
+
+:<<INCLUDE
+INCLUDE
+
+
+################################################################################
+# VARIABLES
+################################################################################
+
+readonly _alias_Version="0.1.0"
+
+################################################################################
+# FUNCTIONS
+################################################################################
+
+:<<FUNCTIONS
+FUNCTIONS
+
+# isAliasWithFile() - check if given string is an alias with aliases file
+#
+# @_alias: string to be checked
+# @_aliasesSource: list of aliases (file)
+#
+# Returns 0 if @alias is an alias, 1 otherwise.
+alias/isAliasWithFile()
+{
+	local _alias="$1"
+	local _aliasesSource="$2"
+	
+	if [[ ! -e "$_aliasesSource" ]]; then
+		return 1
+	fi
+	
+	if grep "^${_alias};" "$_aliasesSource" &>/dev/null; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+
+# isAliasWithDir() - check if given string is an alias with aliases dir
+#
+# Might be faster than with file as aliases source if many aliases are used.
+#
+# @_alias: string to be checked
+# @_aliasesSource: list of aliases (dir)
+#
+# Returns 0 if @alias is an alias, 1 otherwise.
+alias/isAliasWithDir()
+{
+	local _alias="$1"
+	local _aliasesSource="$2"
+	
+	if [[ ! -e "$_aliasesSource" ]]; then
+		return 1
+	fi
+	
+	if [[ -f "${_aliasesSource}/${_alias}" ]]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+
+# dealiasWithFile() - dealias a given string with aliases file
+#
+# @_alias: string do be dealiased (string)
+# @_aliasesSource: list of aliases (file)
+#
+# Prints dealiased string or input string if no alias was used there. If
+# dealiased string is again an alias, it is dealiased again and so forth.
+#
+# Returns 0 if dealiasing worked or if no alias was used. Returns 1 on error.
+alias/dealiasWithFile()
+{
+	local _alias="$1"
+	local _aliasesSource="$2"
+
+	local _currentAlias="$_alias"
+	local _value
+	
+	if [[ ! -e "$_aliasesSource" ]]; then
+		return 1
+	fi
+	
+	while alias/isAliasWithFile "$_alias" "$_aliasesSource"; do
+		_currentAlias="$_alias"
+		_value=$( grep "^${_alias};" "$_aliasesSource" | cut -d ';' -f 2 )
+		if [[ "$_value" != "" ]]; then
+			_alias="$_value"
+		fi
+	done
+
+	# replace all occurances of the "%alias" keyword with current alias
+	_alias=${_alias//\%alias/$_currentAlias}
+
+	eval echo "$_alias"
+	
+	return
+}
+
+
+# dealiasWithDir() - dealias a given string with aliases dir
+#
+# @_alias: string do be dealiased (string)
+# @_aliasesSource: list of aliases (dir)
+#
+# Prints dealiased string or input string if no alias was used there. If
+# dealiased string is again an alias, it is dealiased again and so forth.
+#
+# Returns 0 if dealiasing worked or if no alias was used. Returns 1 on error.
+alias/dealiasWithDir()
+{
+	local _alias="$1"
+	local _aliasesSource="$2"
+
+	local _currentAlias="$_alias"
+	local _value
+	
+	if [[ ! -e "$_aliasesSource" ]]; then
+		return 1
+	fi
+	
+	while alias/isAliasWithDir "$_alias" "$_aliasesSource"; do
+		_currentAlias="$_alias"
+		_value=$( cat "${_aliasesSource}/${_alias}" )
+		if [[ "$_value" != "" ]]; then
+			_alias="$_value"
+		fi
+	done
+
+	# replace all occurances of the "%alias" keyword with current alias
+	_alias=${_alias//\%alias/$_currentAlias}
+
+	eval echo "$_alias"
+	
+	return
+}
+
+
+# isAlias - check if given string is an alias (either file or dir)
+#
+# @_alias: string to be checked
+# @_aliasesSource: list of aliases (file/dir)
+#
+# Returns 0 if @alias is an alias, 1 otherwise.
+alias/isAlias()
+{
+	if [[ -f "$2" ]]; then
+		
+		alias/isAliasWithFile "$@"
+		
+	elif [[ -d "$2" ]]; then
+	
+		alias/isAliasWithDir "$@"
+	
+	else
+		return 1
+	fi
+}
+
+
+# dealias() - dealias a given string with either file or dir as aliases source
+#
+# @_alias: string do be dealiased (string)
+# @_aliasesSource: list of aliases (file/dir)
+#
+# Prints dealiased string or input string if no alias was used there. If
+# dealiased string is again an alias, it is dealiased again and so forth.
+#
+# Returns 0 if dealiasing worked or if no alias was used. Returns 1 on error.
+alias/dealias()
+{
+	if [[ -f "$2" ]]; then
+		
+		alias/dealiasWithFile "$@"
+		
+	elif [[ -d "$2" ]]; then
+	
+		alias/dealiasWithDir "$@"
+	
+	else
+		return 1
+	fi
+}
+
+
+# list() - list aliases available in the given aliases source
+#
+# @_aliasSource: list of aliases (file/dir)
+#
+# Prints all aliases available in the given aliases source.
+#
+# Returns 0 if everthing is OK, 1 if the alias source is neither file nor dir.
+alias/list()
+{
+	local _aliasesSource="$1"
+	
+	if [[ -f "$_aliasesSource" ]]; then
+	
+		cat "$_aliasesSource" | cut -d ';' -f 1
+		
+	elif [[ -d "$_aliasesSource" ]]; then
+	
+		ls -1 "$_aliasesSource"		
+	else
+		return 1
+	fi
+	
+	return
+}
+

--- a/share/doc/host_aliases.md
+++ b/share/doc/host_aliases.md
@@ -1,0 +1,118 @@
+# (gtransfer) host aliases #
+
+* [What is a host alias?](https://github.com/fr4nk5ch31n3r/gtransfer/wiki/Host-aliases#what-is-a-host-alias)
+* [Alias syntax](https://github.com/fr4nk5ch31n3r/gtransfer/wiki/Host-aliases#alias-syntax)
+* [Alias mapping](https://github.com/fr4nk5ch31n3r/gtransfer/wiki/Host-aliases#alias-mapping)
+    * [Alias mapping with file](https://github.com/fr4nk5ch31n3r/gtransfer/wiki/Host-aliases#alias-mapping-with-file)
+    * [Alias mapping with directory](https://github.com/fr4nk5ch31n3r/gtransfer/wiki/Host-aliases#alias-mapping-with-directory)
+
+## What is a host alias? ##
+
+A so-called *host alias* is a string (e.g. `myGridFTP:`) which is mapped to a
+host address (e.g. `gsiftp://host.domain.tld:2811`). Gtransfer supports host
+aliases by using a small helper tool named `halias`. In gtransfer both the
+alias and its expansion can be used synonymical. E.g.:
+
+```shell
+gt -s gsiftp://host.domain.tld:2811/~/file1 -d gsiftp://host.domain.tld:2811/~/file2
+```
+
+...and...
+
+```shell
+gt -s myGridFTP:/~/file1 -d myGridFTP:/~/file2
+```
+
+...will perform the same transfer. The gtransfer bash completion was also
+enhanced to support host aliases. Aliases are proposed as possible host
+addresses like regular host addresses. And you can also browse through remote
+directories when using aliases. Currently the addition of `user@` in front of
+the aliases does not work yet, so if you need to access GridFTP servers with
+non-standard user names, use the regular host addresses currently (e.g.
+`gsiftp://user@host.domain.tld:2811`).
+
+## Alias syntax ##
+
+The following characters are not allowed in alias strings:
+
+* `/`
+* ` ` (space)
+
+Apart from that an alias string has to be a valid file name, too. Also not
+needed, placing a `:` at the end of an alias string mimics the look of SSH URLs,
+so this is recommended.
+
+## Alias mapping ##
+
+Aliases can be mapped to host addresses either by means of a file or a
+directory. If many aliases are available the expansion will be faster if you are
+using a directory. Therefore the recommendation is to use a directory as alias
+source by default.
+
+### Alias mapping with file ###
+
+```shell
+$ cat aliases
+alias1:;gsiftp://host.domain.tld:2811
+myGridFTP:;alias1
+alias3:;$( doSomething )
+alias4:;$( doSomethingWith %alias )
+```
+
+This exemplary alias source also shows what is currently possible:
+
+* `alias1:` will be expanded to the host address `gsiftp://host.domain.tld:2811`
+* `myGridFTP:` maps to `alias1` which itself is again an alias. `myGridFTP:`
+will therefore also be expanded to the host address
+`gsiftp://host.domain.tld:2811`
+
+> **CAUTION**
+> Do not create (expansion) loops (like `myGridFTP:;myGridFTP:`)!
+
+* `alias3:` maps to a so-called *command substitution* and will therefore be
+expanded to what `doSomething` prints out.
+* `alias4:` is similar to `alias3:` but uses the `%alias` keyword. This keyword
+is expanded to the actual alias string (`alias4` in this case) before the
+command is executed. This way you can use the alias string inside of the command
+substitution.
+
+> **CAUTION**
+> To perform the command substitution and to retrieve the output, the `eval`
+> command is used internally. Therefore be careful not to map to something like
+> `rm -rf ~/*`, as this command would be executed during expansion.
+
+### Alias mapping with directory ###
+
+This uses the same mapping as the file above and will be expanded the same way.
+
+```
+$ ls -1 aliases.d
+alias1:
+myGridFTP:
+alias3:
+alias4:
+```
+
+File contents of `alias1:`
+```
+gsiftp://host.domain.tld:2811
+```
+
+File contents of `myGridFTP:`
+```
+alias1:
+```
+Alternatively you could also use a symlink to `alias1:` (saves the time for the
+second expansion)
+
+
+File contents of `alias3:`
+```
+$( doSomething ) 
+```
+
+File contents of `alias4:`
+```
+$( doSomethingWith %alias )
+```
+


### PR DESCRIPTION
This adds support for host aliases to gtransfer. More information can be found in `share/doc/host_aliases.md` or the corresponding [wiki page](https://github.com/fr4nk5ch31n3r/gtransfer/wiki/Host-aliases).
